### PR TITLE
CT-47 블로그 팔로우 요청/취소 기능 구현

### DIFF
--- a/src/main/java/xeat/blogservice/blog/repository/BlogRepository.java
+++ b/src/main/java/xeat/blogservice/blog/repository/BlogRepository.java
@@ -3,5 +3,9 @@ package xeat.blogservice.blog.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import xeat.blogservice.blog.entity.Blog;
 
+import java.util.Optional;
+
 public interface BlogRepository extends JpaRepository<Blog, Long> {
+
+    Optional<Blog> findByUserId(Long userId);
 }

--- a/src/main/java/xeat/blogservice/follow/controller/FollowController.java
+++ b/src/main/java/xeat/blogservice/follow/controller/FollowController.java
@@ -1,0 +1,21 @@
+package xeat.blogservice.follow.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import xeat.blogservice.follow.dto.FollowRequestDto;
+import xeat.blogservice.follow.service.FollowService;
+import xeat.blogservice.global.Response;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/blog/home/follow")
+    public Response<?> follow(@RequestBody FollowRequestDto followRequestDto) {
+        return followService.recommend(followRequestDto);
+    }
+}

--- a/src/main/java/xeat/blogservice/follow/dto/FollowRequestDto.java
+++ b/src/main/java/xeat/blogservice/follow/dto/FollowRequestDto.java
@@ -1,0 +1,14 @@
+package xeat.blogservice.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowRequestDto {
+
+    private Long userId;
+    private Long followUserId;
+}

--- a/src/main/java/xeat/blogservice/follow/dto/FollowResponseDto.java
+++ b/src/main/java/xeat/blogservice/follow/dto/FollowResponseDto.java
@@ -1,0 +1,17 @@
+package xeat.blogservice.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowResponseDto {
+
+    private Integer followCount;
+
+    public static FollowResponseDto toDto(Integer followCount) {
+        return new FollowResponseDto(followCount);
+    }
+}

--- a/src/main/java/xeat/blogservice/follow/repository/FollowRepository.java
+++ b/src/main/java/xeat/blogservice/follow/repository/FollowRepository.java
@@ -1,0 +1,15 @@
+package xeat.blogservice.follow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import xeat.blogservice.blog.entity.Blog;
+import xeat.blogservice.follow.entity.Follow;
+
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByUserIdAndFollowUserId(Long userId, Long followUserId);
+
+    // 회원이 좋아요를 눌렀는지 안눌렀는지 확인 메소드
+    boolean existsByUserIdAndFollowUserId(Long userId, Long followUserId);
+}

--- a/src/main/java/xeat/blogservice/follow/service/FollowService.java
+++ b/src/main/java/xeat/blogservice/follow/service/FollowService.java
@@ -1,0 +1,53 @@
+package xeat.blogservice.follow.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xeat.blogservice.blog.entity.Blog;
+import xeat.blogservice.blog.repository.BlogRepository;
+import xeat.blogservice.follow.dto.FollowRequestDto;
+import xeat.blogservice.follow.dto.FollowResponseDto;
+import xeat.blogservice.follow.entity.Follow;
+import xeat.blogservice.follow.repository.FollowRepository;
+import xeat.blogservice.global.Response;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final BlogRepository blogRepository;
+    private final FollowRepository followRepository;
+
+    @Transactional
+    public Response<?> recommend(FollowRequestDto followRequestDto) {
+
+        Long userId = followRequestDto.getUserId();
+        Long followUserId = followRequestDto.getFollowUserId();
+        
+        Blog blog = blogRepository.findById(userId).get();
+
+        // 팔로우 요청일 경우
+        if (!followRepository.existsByUserIdAndFollowUserId(userId, followUserId)) {
+            Follow follow = Follow.builder()
+                    .user(blogRepository.findById(userId).get())
+                    .followUser(blogRepository.findByUserId(followUserId).get())
+                    .build();
+            Blog updateBlog = blog.toBuilder().
+                    followCount(blog.getFollowCount() + 1)
+                    .build();
+            blogRepository.save(updateBlog);
+            followRepository.save(follow);
+            return new Response<>(200, "사용자 팔로우 요청 성공", FollowResponseDto.toDto(updateBlog.getFollowCount()));
+        }
+
+        // 팔로우 요청 취소일 경우
+        else {
+            followRepository.delete(followRepository.findByUserIdAndFollowUserId(userId, followUserId).get());
+            Blog updateBlog = blog.toBuilder().
+                    followCount(blog.getFollowCount() - 1)
+                    .build();
+            blogRepository.save(updateBlog);
+            return new Response<>(200, "사용자 팔로우 요청 취소 성공", FollowResponseDto.toDto(updateBlog.getFollowCount()));
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 티켓 넘버

> CT-47

## 📝작업 내용

> 블로그 팔로우 요청 및 취소 기능 관련 POST API를 제작하였습니다.
>
> flow는 다음과 같습니다.
> 사용자가 팔로우 버튼 click -> service 단에서 자동으로 팔로우 요청인지 취소인지 구분
> 팔로우 요청일 경우 : blog 테이블의 follow_count + 1 and follow 테이블에 내용 추가
> 팔로우 취소일 경우 : blog 테이블의 follow_count - 1 and follow 테이블에 있던 내용 삭제 
> response 값으로는 요청 및 취소 관계없이 해당 블로그의 팔로우 수를 반환