### PR TITLE
CT-105 코딩테스트 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/xeat/blogservice/article/dto/ArticleResponseDto.java
+++ b/src/main/java/xeat/blogservice/article/dto/ArticleResponseDto.java
@@ -1,0 +1,5 @@
+package xeat.blogservice.article.dto;
+
+
+public class ArticleResponseDto {
+}

--- a/src/main/java/xeat/blogservice/article/entity/Article.java
+++ b/src/main/java/xeat/blogservice/article/entity/Article.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import xeat.blogservice.article.dto.ArticleEditRequestDto;
 import xeat.blogservice.blog.entity.Blog;
 import xeat.blogservice.childcategory.entity.ChildCategory;
+import xeat.blogservice.codearticle.dto.CodeArticleEditRequestDto;
 import xeat.blogservice.codearticle.entity.CodeArticle;
 import xeat.blogservice.global.FullTimeEntity;
 import xeat.blogservice.recommend.entity.Recommend;
@@ -83,20 +84,16 @@ public class Article extends FullTimeEntity {
     private Integer reportCount;
 
     @Builder.Default
-    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<Recommend> recommends = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<Reply> replies = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<UserReport> userReports = new ArrayList<>();
-
-    @Builder.Default
-    @OneToOne(mappedBy = "article", cascade = CascadeType.REMOVE)
-    private CodeArticle codeArticle = new CodeArticle();
 
     public void editArticle(ArticleEditRequestDto articleEditRequestDto, ChildCategory childCategory) {
         this.childCategory = childCategory;
@@ -104,6 +101,13 @@ public class Article extends FullTimeEntity {
         this.content = articleEditRequestDto.getContent();
         this.isSecret = articleEditRequestDto.getIsSecret();
         this.password = articleEditRequestDto.getPassword();
+    }
+
+    public void editCodeArticle(CodeArticleEditRequestDto codeArticleEditRequestDto) {
+        this.title = codeArticleEditRequestDto.getTitle();
+        this.content = codeArticleEditRequestDto.getContent();
+        this.isSecret = codeArticleEditRequestDto.getIsSecret();
+        this.password = codeArticleEditRequestDto.getPassword();
     }
 
 

--- a/src/main/java/xeat/blogservice/article/service/ArticleService.java
+++ b/src/main/java/xeat/blogservice/article/service/ArticleService.java
@@ -11,6 +11,7 @@ import xeat.blogservice.article.repository.ArticleRepository;
 import xeat.blogservice.blog.repository.BlogRepository;
 import xeat.blogservice.childcategory.entity.ChildCategory;
 import xeat.blogservice.childcategory.repository.ChildCategoryRepository;
+import xeat.blogservice.codearticle.repository.CodeArticleRepository;
 import xeat.blogservice.global.Response;
 
 @Service
@@ -21,6 +22,7 @@ public class ArticleService {
     private final BlogRepository blogRepository;
     private final ChildCategoryRepository childCategoryRepository;
     private final ArticleRepository articleRepository;
+    private final CodeArticleRepository codeArticleRepository;
 
     @Transactional
     public Response<Article> post(ArticlePostRequestDto articlePostRequestDto) {
@@ -31,7 +33,6 @@ public class ArticleService {
                 .title(articlePostRequestDto.getTitle())
                 .content(articlePostRequestDto.getContent())
                 .isSecret(articlePostRequestDto.getIsSecret())
-                .isBlind(articlePostRequestDto.getIsBlind())
                 .password(articlePostRequestDto.getPassword())
                 .build();
         return Response.success(articleRepository.save(article));
@@ -49,6 +50,12 @@ public class ArticleService {
     @Transactional
     public Response<?> delete(Long articleId) {
         articleRepository.deleteById(articleId);
+
+        if (codeArticleRepository.existsByArticleId(articleId)) {
+            codeArticleRepository.delete(codeArticleRepository.findByArticleId(articleId).get());
+        }
         return new Response<>(200, "게시글 삭제 완료", null);
     }
+
+
 }

--- a/src/main/java/xeat/blogservice/codearticle/controller/CodeArticleController.java
+++ b/src/main/java/xeat/blogservice/codearticle/controller/CodeArticleController.java
@@ -1,10 +1,10 @@
 package xeat.blogservice.codearticle.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import xeat.blogservice.codearticle.dto.CodeArticleEditRequestDto;
 import xeat.blogservice.codearticle.dto.CodeArticlePostRequestDto;
+import xeat.blogservice.codearticle.dto.CodeArticleResponseDto;
 import xeat.blogservice.codearticle.service.CodeArticleService;
 import xeat.blogservice.global.Response;
 
@@ -15,7 +15,12 @@ public class CodeArticleController {
     private final CodeArticleService codeArticleService;
 
     @PostMapping("/blog/board/code")
-    public Response<CodeArticlePostRequestDto> postCodeArticle(@RequestBody CodeArticlePostRequestDto codeArticlePostRequestDto) {
+    public Response<CodeArticleResponseDto> postCodeArticle(@RequestBody CodeArticlePostRequestDto codeArticlePostRequestDto) {
         return codeArticleService.post(codeArticlePostRequestDto);
+    }
+
+    @PutMapping("/blog/board/code/edit/{articleId}")
+    public Response<CodeArticleResponseDto> editCodeArticle(@PathVariable Long articleId, @RequestBody CodeArticleEditRequestDto codeArticleEditRequestDto) {
+        return codeArticleService.edit(articleId, codeArticleEditRequestDto);
     }
 }

--- a/src/main/java/xeat/blogservice/codearticle/dto/CodeArticleEditRequestDto.java
+++ b/src/main/java/xeat/blogservice/codearticle/dto/CodeArticleEditRequestDto.java
@@ -1,16 +1,13 @@
-package xeat.blogservice.article.dto;
+package xeat.blogservice.codearticle.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
-public class ArticlePostRequestDto {
-    private Long blogId;
-
-    private Long childCategoryId;
+@NoArgsConstructor
+public class CodeArticleEditRequestDto {
 
     private String title;
 
@@ -19,4 +16,9 @@ public class ArticlePostRequestDto {
     private Boolean isSecret;
 
     private String password;
+
+
+    private String codeContent;
+
+    private String writtenCode;
 }

--- a/src/main/java/xeat/blogservice/codearticle/dto/CodeArticlePostRequestDto.java
+++ b/src/main/java/xeat/blogservice/codearticle/dto/CodeArticlePostRequestDto.java
@@ -15,7 +15,6 @@ public class CodeArticlePostRequestDto {
     private String title;
     private String content;
     private Boolean isSecret;
-    private Boolean isBlind;
     private String password;
 
     //코딩테스트 게시글만 별도로 저장
@@ -24,19 +23,4 @@ public class CodeArticlePostRequestDto {
     private String codeContent;
     private String writtenCode;
 
-    public static CodeArticlePostRequestDto toDto(Article article, CodeArticle codeArticle) {
-        return new CodeArticlePostRequestDto(
-                article.getBlog().getId(),
-                article.getTitle(),
-                article.getContent(),
-                article.getIsSecret(),
-                article.getIsBlind(),
-                article.getPassword(),
-
-                codeArticle.getDifficulty(),
-                codeArticle.getCodeId(),
-                codeArticle.getCodeContent(),
-                codeArticle.getWrittenCode()
-        );
-    }
 }

--- a/src/main/java/xeat/blogservice/codearticle/dto/CodeArticleResponseDto.java
+++ b/src/main/java/xeat/blogservice/codearticle/dto/CodeArticleResponseDto.java
@@ -1,0 +1,43 @@
+package xeat.blogservice.codearticle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xeat.blogservice.article.entity.Article;
+import xeat.blogservice.codearticle.entity.CodeArticle;
+import xeat.blogservice.codearticle.entity.Difficulty;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CodeArticleResponseDto {
+
+    private Long blogId;
+    private String title;
+    private String content;
+    private Boolean isSecret;
+    private Boolean isBlind;
+    private String password;
+
+    //코딩테스트 게시글만 별도로 저장
+    private Difficulty difficulty;
+    private Long codeId;
+    private String codeContent;
+    private String writtenCode;
+
+    public static CodeArticleResponseDto toDto(Article article, CodeArticle codeArticle) {
+        return new CodeArticleResponseDto(
+                article.getBlog().getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getIsSecret(),
+                article.getIsBlind(),
+                article.getPassword(),
+
+                codeArticle.getDifficulty(),
+                codeArticle.getCodeId(),
+                codeArticle.getCodeContent(),
+                codeArticle.getWrittenCode()
+        );
+    }
+}

--- a/src/main/java/xeat/blogservice/codearticle/entity/CodeArticle.java
+++ b/src/main/java/xeat/blogservice/codearticle/entity/CodeArticle.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import xeat.blogservice.codearticle.dto.CodeArticleEditRequestDto;
 import xeat.blogservice.global.CreatedTimeEntity;
 import xeat.blogservice.article.entity.Article;
 
@@ -20,7 +21,7 @@ public class CodeArticle extends CreatedTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="CODE_ARTICLE_ID")
-    private long id;
+    private Long id;
 
     @OneToOne
     @JoinColumn(name = "ARTICLE_ID", referencedColumnName = "ARTICLE_ID")
@@ -28,18 +29,19 @@ public class CodeArticle extends CreatedTimeEntity {
 
     @Column(name = "DIFFICULTY")
     @Enumerated(EnumType.STRING)
-    @NotNull
     private Difficulty difficulty;
 
     @Column(name = "CODE_ID")
-    @NotNull
-    private long codeId;
+    private Long codeId;
 
     @Column(name = "CODE_CONTENT")
-    @NotNull
     private String codeContent;
 
     @Column(name = "WRITTEN_CODE")
-    @NotNull
     private String writtenCode;
+
+    public void editCodeArticle(CodeArticleEditRequestDto codeArticleEditRequestDto) {
+        this.codeContent = codeArticleEditRequestDto.getCodeContent();
+        this.writtenCode = codeArticleEditRequestDto.getWrittenCode();
+    }
 }

--- a/src/main/java/xeat/blogservice/codearticle/repository/CodeArticleRepository.java
+++ b/src/main/java/xeat/blogservice/codearticle/repository/CodeArticleRepository.java
@@ -2,6 +2,11 @@ package xeat.blogservice.codearticle.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import xeat.blogservice.codearticle.entity.CodeArticle;
+import java.util.Optional;
 
 public interface CodeArticleRepository extends JpaRepository<CodeArticle, Long> {
+
+    boolean existsByArticleId(Long articleId);
+
+    Optional<CodeArticle> findByArticleId(Long articleId);
 }

--- a/src/main/java/xeat/blogservice/codearticle/service/CodeArticleService.java
+++ b/src/main/java/xeat/blogservice/codearticle/service/CodeArticleService.java
@@ -6,7 +6,9 @@ import org.springframework.transaction.annotation.Transactional;
 import xeat.blogservice.article.entity.Article;
 import xeat.blogservice.article.repository.ArticleRepository;
 import xeat.blogservice.blog.repository.BlogRepository;
+import xeat.blogservice.codearticle.dto.CodeArticleEditRequestDto;
 import xeat.blogservice.codearticle.dto.CodeArticlePostRequestDto;
+import xeat.blogservice.codearticle.dto.CodeArticleResponseDto;
 import xeat.blogservice.codearticle.entity.CodeArticle;
 import xeat.blogservice.codearticle.repository.CodeArticleRepository;
 import xeat.blogservice.global.Response;
@@ -20,13 +22,12 @@ public class CodeArticleService {
     private final CodeArticleRepository codeArticleRepository;
 
     @Transactional
-    public Response<CodeArticlePostRequestDto> post(CodeArticlePostRequestDto codeArticlePostRequestDto) {
+    public Response<CodeArticleResponseDto> post(CodeArticlePostRequestDto codeArticlePostRequestDto) {
         Article article = Article.builder()
                 .blog(blogRepository.findById(codeArticlePostRequestDto.getBlogId()).get())
                 .title(codeArticlePostRequestDto.getTitle())
                 .content(codeArticlePostRequestDto.getContent())
                 .isSecret(codeArticlePostRequestDto.getIsSecret())
-                .isBlind(codeArticlePostRequestDto.getIsBlind())
                 .password(codeArticlePostRequestDto.getPassword())
                 .build();
         articleRepository.save(article);
@@ -41,7 +42,22 @@ public class CodeArticleService {
 
         codeArticleRepository.save(codeArticle);
 
-        return Response.success(CodeArticlePostRequestDto.toDto(article, codeArticle));
+        return Response.success(CodeArticleResponseDto.toDto(article, codeArticle));
+    }
+
+    @Transactional
+    public Response<CodeArticleResponseDto> edit(Long articleId, CodeArticleEditRequestDto codeArticleEditRequestDto) {
+        CodeArticle codeArticle = codeArticleRepository.findByArticleId(articleId).get();
+
+        Article article = articleRepository.findById(codeArticle.getArticle().getId()).get();
+
+        article.editCodeArticle(codeArticleEditRequestDto);
+        codeArticle.editCodeArticle(codeArticleEditRequestDto);
+
+        articleRepository.save(article);
+        codeArticleRepository.save(codeArticle);
+
+        return Response.success(CodeArticleResponseDto.toDto(article, codeArticle));
     }
 
 }

--- a/src/main/java/xeat/blogservice/reply/dto/ReplyPostRequestDto.java
+++ b/src/main/java/xeat/blogservice/reply/dto/ReplyPostRequestDto.java
@@ -15,6 +15,8 @@ public class ReplyPostRequestDto {
 
     private Long parentReplyId;
 
+    private Long mentionedUserId;
+
     private String content;
 
 

--- a/src/main/java/xeat/blogservice/reply/dto/ReplyPostResponseDto.java
+++ b/src/main/java/xeat/blogservice/reply/dto/ReplyPostResponseDto.java
@@ -14,14 +14,18 @@ public class ReplyPostResponseDto {
 
     private Long userId;
 
+    private Long mentionedUserId;
+
     private Long parentReplyId;
+
 
     private String content;
 
-    public static ReplyPostResponseDto toDto(Reply reply) {
+    public static ReplyPostResponseDto toDto(Reply reply, Long mentionedUserId) {
         return new ReplyPostResponseDto(
                 reply.getArticle().getId(),
                 reply.getUser().getUserId(),
+                mentionedUserId,
                 reply.getParentReplyId(),
                 reply.getContent()
         );

--- a/src/main/java/xeat/blogservice/reply/entity/Reply.java
+++ b/src/main/java/xeat/blogservice/reply/entity/Reply.java
@@ -30,6 +30,10 @@ public class Reply extends FullTimeEntity {
     @JoinColumn(name = "USER_ID", referencedColumnName = "USER_ID")
     private Blog user;
 
+    @ManyToOne
+    @JoinColumn(name = "MENTIONED_USER_ID", referencedColumnName = "USER_ID")
+    private Blog mentionedUser;
+
     @Column(name = "PARENT_REPLY_ID")
     private Long parentReplyId;
 

--- a/src/main/java/xeat/blogservice/reply/service/ReplyService.java
+++ b/src/main/java/xeat/blogservice/reply/service/ReplyService.java
@@ -30,9 +30,16 @@ public class ReplyService {
     @Transactional
     public Response<ReplyPostResponseDto> replyPost(ReplyPostRequestDto replyPostRequestDto) {
 
+        Blog mentionedUser = null;
+
+        if (replyPostRequestDto.getMentionedUserId() != null) {
+            mentionedUser = blogRepository.findByUserId(replyPostRequestDto.getMentionedUserId()).get();
+        }
+
         Reply reply = Reply.builder()
                 .article(articleRepository.findById(replyPostRequestDto.getArticleId()).get())
                 .user(blogRepository.findByUserId(replyPostRequestDto.getUserId()).get())
+                .mentionedUser(mentionedUser)
                 .parentReplyId(replyPostRequestDto.getParentReplyId())
                 .content(replyPostRequestDto.getContent())
                 .build();
@@ -54,7 +61,7 @@ public class ReplyService {
 
         noticeRepository.save(notice);
 
-        return Response.success(ReplyPostResponseDto.toDto(reply));
+        return Response.success(ReplyPostResponseDto.toDto(reply, replyPostRequestDto.getMentionedUserId()));
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 티켓 넘버

> CT-105

## 📝작업 내용

> 코딩테스트 게시글 수정 기능 관련 PUT API를 제작하였습니다.
> 이와 더불어 코딩테스트 게시글과 그냥 게시글이 현재 OneToOne 관계로 매핑이 되어있는 상태인데 여기서 일반 게시글을 작성할 시 코딩테스트 게시글도  null값으로 자동으로 만들어진다는 문제점이 발생하였습니다.
> 이를 해결하기 위해 일반 게시글 entity에 있는 OneToOne 어노테이션을 제외하였고 일반게시글이 삭제될시 code_article table에서 참조 중이던 컬럼까지 함께 삭제되도록 직접 구현하는 방식을 선택하였습니다.