### PR TITLE
CT-110 게시글 상세 조회 기능 구현

### DIFF
--- a/src/main/java/xeat/blogservice/article/controller/ArticleController.java
+++ b/src/main/java/xeat/blogservice/article/controller/ArticleController.java
@@ -14,6 +14,11 @@ public class ArticleController {
 
     private final ArticleService articleService;
 
+    @GetMapping("/blog/board/{articleId}")
+    public Response<?> getArticle(@PathVariable Long articleId) {
+        return articleService.getArticle(articleId);
+    }
+
     @PostMapping("/blog/board/article")
     public Response<Article> postArticle(@RequestBody ArticlePostRequestDto articlePostRequestDto) {
         return articleService.post(articlePostRequestDto);

--- a/src/main/java/xeat/blogservice/article/dto/GetArticleResponseDto.java
+++ b/src/main/java/xeat/blogservice/article/dto/GetArticleResponseDto.java
@@ -1,0 +1,41 @@
+package xeat.blogservice.article.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xeat.blogservice.article.entity.Article;
+import xeat.blogservice.reply.dto.ArticleReplyResponseDto;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetArticleResponseDto {
+
+    private Long articleId;
+    private Long blogId;
+    private Long childCategoryId;
+    private String title;
+    private String content;
+    private Integer viewCount;
+    private Integer likeCount;
+    private Integer reportCount;
+    private Integer replyCount;
+    private List<ArticleReplyResponseDto> articleReplies;
+
+    public static GetArticleResponseDto toDto(Article article, List<ArticleReplyResponseDto> articleReplies) {
+        return new GetArticleResponseDto(
+                article.getId(),
+                article.getBlog().getId(),
+                article.getChildCategory().getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getViewCount(),
+                article.getLikeCount(),
+                article.getReportCount(),
+                article.getReplyCount(),
+                articleReplies
+        );
+    }
+}

--- a/src/main/java/xeat/blogservice/codearticle/dto/GetCodeArticleResponseDto.java
+++ b/src/main/java/xeat/blogservice/codearticle/dto/GetCodeArticleResponseDto.java
@@ -1,0 +1,52 @@
+package xeat.blogservice.codearticle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xeat.blogservice.article.entity.Article;
+import xeat.blogservice.codearticle.entity.CodeArticle;
+import xeat.blogservice.codearticle.entity.Difficulty;
+import xeat.blogservice.reply.dto.ArticleReplyResponseDto;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetCodeArticleResponseDto {
+    private Long articleId;
+    private Long blogId;
+    private String title;
+    private String content;
+    private Integer viewCount;
+    private Integer likeCount;
+    private Integer reportCount;
+    private Integer replyCount;
+
+    // 코딩 테스트 게시글 정보
+    private Difficulty difficulty;
+    private Long codeId;
+    private String codeContent;
+    private String writtenCode;
+
+
+    private List<ArticleReplyResponseDto> articleReplies;
+
+    public static GetCodeArticleResponseDto toDto(Article article, CodeArticle codeArticle, List<ArticleReplyResponseDto> articleReplies) {
+        return new GetCodeArticleResponseDto(
+                article.getId(),
+                article.getBlog().getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getViewCount(),
+                article.getLikeCount(),
+                article.getReportCount(),
+                article.getReplyCount(),
+                codeArticle.getDifficulty(),
+                codeArticle.getCodeId(),
+                codeArticle.getCodeContent(),
+                codeArticle.getWrittenCode(),
+                articleReplies
+        );
+    }
+}

--- a/src/main/java/xeat/blogservice/reply/dto/ArticleReplyResponseDto.java
+++ b/src/main/java/xeat/blogservice/reply/dto/ArticleReplyResponseDto.java
@@ -1,0 +1,31 @@
+package xeat.blogservice.reply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xeat.blogservice.reply.entity.Reply;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleReplyResponseDto {
+
+    private Long replyId;
+    private Long userId;
+    private String content;
+    private LocalDateTime createdDate;
+    private List<ChildReplyResponseDto> childReplies;
+
+    public static ArticleReplyResponseDto toDto(Reply reply, List<ChildReplyResponseDto> childList) {
+        return new ArticleReplyResponseDto(
+                reply.getId(),
+                reply.getUser().getUserId(),
+                reply.getContent(),
+                reply.getCreatedDate(),
+                childList
+        );
+    }
+}

--- a/src/main/java/xeat/blogservice/reply/dto/ChildReplyResponseDto.java
+++ b/src/main/java/xeat/blogservice/reply/dto/ChildReplyResponseDto.java
@@ -1,0 +1,31 @@
+package xeat.blogservice.reply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xeat.blogservice.reply.entity.Reply;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChildReplyResponseDto {
+    private Long replyId;
+    private Long userId;
+    private Long parentReplyId;
+    private Long mentionedUserId;
+    private String content;
+    private LocalDateTime createdDate;
+
+    public static ChildReplyResponseDto toDto(Reply reply) {
+        return new ChildReplyResponseDto(
+                reply.getId(),
+                reply.getUser().getId(),
+                reply.getParentReplyId(),
+                reply.getMentionedUser().getUserId(),
+                reply.getContent(),
+                reply.getCreatedDate()
+        );
+    }
+}

--- a/src/main/java/xeat/blogservice/reply/repository/ReplyRepository.java
+++ b/src/main/java/xeat/blogservice/reply/repository/ReplyRepository.java
@@ -1,7 +1,16 @@
 package xeat.blogservice.reply.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import xeat.blogservice.reply.entity.Reply;
 
+import java.util.List;
+
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
+
+    @Query("SELECT m FROM Reply m WHERE m.parentReplyId IS NULL AND m.article.id = :articleId")
+    List<Reply> findParentReplies(@Param("articleId") Long articleId);
+
+    List<Reply> findAllByParentReplyId(Long parentReplyId);
 }


### PR DESCRIPTION
## #️⃣연관된 티켓 넘버

> CT-110

## 📝작업 내용

> 게시글과 코딩테스트 게시글 상세조회 기능 관련 GET API를 제작하였습니다.
> articleId를 코딩테스트 repository에서 검색해서 있을 경우 코딩테스트 게시글 dto로 반환하고 없을 경우 일반 게시글 dto로 반환하는 방식을 선택하였습니다.
> 댓글도 함께 반환되어야 하므로 dto에 댓글을 list로 만들어놓은 후 해당 게시글의 댓글과 대댓글들을 출력하도록 구현하였습니다.